### PR TITLE
Devops 8747 adding publish gem workflow

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,6 +1,7 @@
 name: Publish Gem
 
-on:   [push, workflow_dispatch]
+on: 
+  workflow_dispatch:
   
 jobs:
   Dotnet-build:


### PR DESCRIPTION
https://strongmind.atlassian.net/browse/DEVOPS-8747

## Purpose 
Publish gem to rubygems.org

## Approach 
Added prefix of 'strongmind' to name of gem.
Changed allowed_push_host url to rubygems.org.

## Testing
Verified successful push to rubygems.org
Skipped tests to get gem to push. Re-enabling tests on reusable workflow, expect next run to fail.

## Screenshots/Video
![image](https://user-images.githubusercontent.com/101292749/235550102-761f881a-208d-4033-b208-e49e1a72456c.png)
