### PR TITLE
Bring oauth middleware in and remove faraday_middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,5 @@ gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
 
-gem 'faraday'
-gem 'faraday_middleware'
-gem 'oauth'
+gem 'faraday', '>= 2.0'
+gem 'simple_oauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    strongmind-schoology-client (0.1.2)
-      faraday (~> 1.1)
-      faraday_middleware (~> 1.2)
+    strongmind-schoology-client (0.1.3)
+      faraday (>= 2.0)
       rails (~> 7.0)
       railties (~> 7.0)
       simple_oauth (~> 0.3.1)
@@ -83,40 +82,18 @@ GEM
     date (3.3.3)
     diff-lcs (1.5.0)
     erubi (1.12.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
+    faraday-net_http (3.0.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    hashie (5.0.0)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
-    loofah (2.20.0)
+    loofah (2.21.2)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -126,7 +103,6 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.18.0)
-    multipart-post (2.3.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -137,14 +113,10 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.14.3-x86_64-darwin)
+    nokogiri (1.14.4-arm64-darwin)
       racc (~> 1.4)
-    oauth (1.1.0)
-      oauth-tty (~> 1.0, >= 1.0.1)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
-    oauth-tty (1.0.5)
-      version_gem (~> 1.1, >= 1.1.1)
+    nokogiri (1.14.4-x86_64-darwin)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
@@ -210,15 +182,11 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     simple_oauth (0.3.1)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
-    thor (1.2.1)
+    thor (1.2.2)
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    version_gem (1.1.2)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -230,12 +198,11 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
-  faraday
-  faraday_middleware
-  oauth
+  faraday (>= 2.0)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  simple_oauth
   strongmind-schoology-client!
 
 BUNDLED WITH

--- a/lib/schoology_client.rb
+++ b/lib/schoology_client.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "faraday"
-require "faraday_middleware"
 require "rails"
 require_relative "schoology_client/version"
 
@@ -22,6 +21,10 @@ module SchoologyClient
 
   # Classes used to return a nicer object wrapping the response data
   autoload :Group, "schoology/objects/group"
+
+
+  autoload :OAuth,           'schoology_client/oauth'
+  Faraday::Request.register_middleware oauth: -> { OAuth }
 
   def self.configuration
     @configuration ||= SchoologyClient::Configuration.new

--- a/lib/schoology_client/client.rb
+++ b/lib/schoology_client/client.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'faraday'
-require 'faraday_middleware'
-require 'simple_oauth'
+
 
 module SchoologyClient
   class Client

--- a/lib/schoology_client/oauth.rb
+++ b/lib/schoology_client/oauth.rb
@@ -1,0 +1,85 @@
+require 'faraday'
+require 'simple_oauth'
+require 'forwardable'
+
+module SchoologyClient
+  # Public: Uses the simple_oauth library to sign requests according the
+  # OAuth protocol.
+  #
+  # The options for this middleware are forwarded to SimpleOAuth::Header:
+  # :consumer_key, :consumer_secret, :token, :token_secret. All these
+  # parameters are optional.
+  #
+  # The signature is added to the "Authorization" HTTP request header. If the
+  # value for this header already exists, it is not overriden.
+  #
+  # If no Content-Type header is specified, this middleware assumes that
+  # request body parameters should be included while signing the request.
+  # Otherwise, it only includes them if the Content-Type is
+  # "application/x-www-form-urlencoded", as per OAuth 1.0.
+  #
+  # For better performance while signing requests, this middleware should be
+  # positioned before UrlEncoded middleware on the stack, but after any other
+  # body-encoding middleware (such as EncodeJson).
+  class OAuth < Faraday::Middleware
+    AUTH_HEADER = 'Authorization'
+    CONTENT_TYPE = 'Content-Type'
+    TYPE_URLENCODED = 'application/x-www-form-urlencoded'
+
+    extend Forwardable
+    def_delegator :'Faraday::Utils', :parse_nested_query
+
+    def initialize(app, options)
+      super(app)
+      @options = options
+    end
+
+    def call(env)
+      env[:request_headers][AUTH_HEADER] ||= oauth_header(env).to_s if sign_request?(env)
+      @app.call(env)
+    end
+
+    def oauth_header(env)
+      SimpleOAuth::Header.new env[:method],
+                              env[:url].to_s,
+                              signature_params(body_params(env)),
+                              oauth_options(env)
+    end
+
+    def sign_request?(env)
+      !!env[:request].fetch(:oauth, true)
+    end
+
+    def oauth_options(env)
+      if (extra = env[:request][:oauth]) && extra.is_a?(Hash) && !extra.empty?
+        @options.merge extra
+      else
+        @options
+      end
+    end
+
+    def body_params(env)
+      if include_body_params?(env)
+        if env[:body].respond_to?(:to_str)
+          parse_nested_query env[:body]
+        else
+          env[:body]
+        end
+      end || {}
+    end
+
+    def include_body_params?(env)
+      # see RFC 5849, section 3.4.1.3.1 for details
+      !(type = env[:request_headers][CONTENT_TYPE]) || (type == TYPE_URLENCODED)
+    end
+
+    def signature_params(params)
+      if params.empty?
+        params
+      else
+        params.reject { |_k, v| v.respond_to?(:content_type) }
+      end
+    end
+  end
+
+end

--- a/strongmind-schoology-client.gemspec
+++ b/strongmind-schoology-client.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency "faraday", '~> 1.1'
-  spec.add_dependency "faraday_middleware", '~> 1.2'
+  spec.add_dependency "faraday", '>= 2.0'
   spec.add_dependency "simple_oauth", '~> 0.3.1'
   spec.add_dependency "rails", '~> 7.0'
   spec.add_dependency "railties", "~> 7.0"


### PR DESCRIPTION
## Purpose 
This allows us to upgrade faraday and thereby use platform-ruby-sdk along with this client.

## Approach 
Bring in the oauth middleware code directly into this codebase.

## Testing
Unit tests
