### PR TITLE
QTY-3364 - Add PUT request for Schoology Group to update Name

### DIFF
--- a/lib/schoology_client/resource.rb
+++ b/lib/schoology_client/resource.rb
@@ -12,6 +12,10 @@ module SchoologyClient
       handle_response @client.connection.post(url, body, headers)
     end
 
+    def put_request(url, body:, headers: {})
+      handle_response @client.connection.put(url, body, headers)
+    end
+
     def handle_response(response)
       case response.status
       when 400

--- a/lib/schoology_client/resources/group.rb
+++ b/lib/schoology_client/resources/group.rb
@@ -6,6 +6,10 @@ module SchoologyClient
     def create(**attributes)
       GroupResource.new post_request("groups", body: attributes.to_json).body
     end
+
+    def update(id, **attributes)
+      GroupResource.new put_request("groups/#{id}", body: attributes.to_json).body
+    end
   end
 end
 

--- a/lib/schoology_client/version.rb
+++ b/lib/schoology_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchoologyClient
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/schoology-client/resources/group_spec.rb
+++ b/spec/schoology-client/resources/group_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe SchoologyClient::GroupResource do
         group_id = 1
         body = {
           title: 'Updated Group',
-          description: 'This is an updated group'
         }
 
         stub = stub_request("groups/#{group_id}", method: :put, body: body, response: stub_response(fixture: nil, status: 200))
@@ -55,7 +54,6 @@ RSpec.describe SchoologyClient::GroupResource do
         group_id = 1
         body = {
           title: '',
-          description: 'This is an updated group'
         }
 
         error_message = 'Your request was malformed. error'

--- a/spec/schoology-client/resources/group_spec.rb
+++ b/spec/schoology-client/resources/group_spec.rb
@@ -32,4 +32,42 @@ RSpec.describe SchoologyClient::GroupResource do
     expect(group_result['description']).to eq("This is a test group")
   end
 
+  describe 'Update Schoology Group Folder Name' do
+    context 'with valid parameters' do
+      it 'updates the group name' do
+        group_id = 1
+        body = {
+          title: 'Updated Group',
+          description: 'This is an updated group'
+        }
+
+        stub = stub_request("groups/#{group_id}", method: :put, body: body, response: stub_response(fixture: nil, status: 200))
+        conn = Faraday.new(SchoologyClient.configuration.url) { |b| b.adapter(:test, stub) }
+        client = SchoologyClient::Client.new(conn)
+        group = client.group.update(group_id, **body)
+
+        expect(group).to be_a(SchoologyClient::GroupResource)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'raises an error' do
+        group_id = 1
+        body = {
+          title: '',
+          description: 'This is an updated group'
+        }
+
+        error_message = 'Your request was malformed. error'
+        stub = stub_request("groups/#{group_id}", method: :put, body: body, response: stub_response(fixture: nil, status: 400, body: { 'error' => error_message }.to_json))
+        conn = Faraday.new(SchoologyClient.configuration.url) { |b| b.adapter(:test, stub) }
+        client = SchoologyClient::Client.new(conn)
+
+        expect {
+          client.group.update(group_id, **body)
+        }.to raise_error(SchoologyClient::Error, error_message)
+      end
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,12 @@ RSpec.configure do |config|
   end
 end
 
-def stub_response(fixture:, status: 200, headers: {"Content-Type" => "application/json"})
-  [status, headers, File.read("spec/fixtures/#{fixture}.json")]
+def stub_response(fixture: nil, status: 200, headers: { "Content-Type" => "application/json" }, body: "")
+  if fixture.nil?
+    [status, headers, body]
+  else
+    [status, headers, File.read("spec/fixtures/#{fixture}.json")]
+  end
 end
 
 def stub_request(path, response:, method: :get, body: {})


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-3364)

## Purpose 
We want the ability to update a Schoology group folder name that is already existing. 

## Approach 
- Added the endpoint for schoology
- Created new methods to handle the PUT request. Taking in the necessary parameters.
- Create tests

## Testing
Create tests for happy/sad path for the new PUT request

## Screenshots/Video
<img width="758" alt="image" src="https://github.com/StrongMind/schoology-client/assets/106628145/c57bb087-41d7-44b9-8a4d-da5413bbcc36">
